### PR TITLE
bug/40-file-download

### DIFF
--- a/BFE_RShiny/flamingo/R/ViewFilesInTable_module.R
+++ b/BFE_RShiny/flamingo/R/ViewFilesInTable_module.R
@@ -327,7 +327,7 @@ ViewFilesInTable <- function(input, output, session,
 
   # Export to .csv
   output$FVEdownloadexcel <- downloadHandler(
-    filename = result$currentFile,
+    filename = function(){paste0(result$currentFile)},
     content = function(file) {
       fwrite(result$tbl_fileData, file, row.names = TRUE, quote = TRUE)}
   )

--- a/BFE_RShiny/flamingo/R/ViewFilesInTable_module.R
+++ b/BFE_RShiny/flamingo/R/ViewFilesInTable_module.R
@@ -327,7 +327,7 @@ ViewFilesInTable <- function(input, output, session,
 
   # Export to .csv
   output$FVEdownloadexcel <- downloadHandler(
-    filename = function(){paste0(result$currentFile)},
+    filename = function(){result$currentFile},
     content = function(file) {
       fwrite(result$tbl_fileData, file, row.names = TRUE, quote = TRUE)}
   )


### PR DESCRIPTION
Fixes #40 
After downloading a single file from any of the file lists, subsequent requests to download a different file results in the correct file downloaded but with the name of the previous file. This file name persists for all other files downloaded until logging out of flamingo.

After the fix the file is downloaded with correct filename.

Reason:
the shiny `downloadHandler` widget requires the filename to be either a string or a function returning a string. Therefore a function should be used to pass to the widget a reactive value that contains the filename as a string.