### PR TITLE
feature/55-replace "event_occurrence_file_id" with "event_occurrence_id" 

### DIFF
--- a/BFE_RShiny/.gitignore
+++ b/BFE_RShiny/.gitignore
@@ -5,3 +5,5 @@ notes.md
 .project
 .Rd2pdf*
 *.pdf
+Rlibrary
+*.Rprofile

--- a/BFE_RShiny/flamingo/R/API_analyses_id.R
+++ b/BFE_RShiny/flamingo/R/API_analyses_id.R
@@ -288,9 +288,9 @@ construct_analysis_settings <- function(inputsettings, outputsLossTypes) {
       "path" = "model_settings",
       "value" =  inputsettings$peril_surge
     ),
-    "event_occurrence_file_id" = list(
+    "event_occurrence_id" = list(
       "path" = "model_settings",
-      "value" =  inputsettings$event_occurrence_file_id
+      "value" =  inputsettings$event_occurrence_id
     )
   )
 

--- a/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
+++ b/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
@@ -1236,7 +1236,7 @@ step3_configureOutput <- function(input, output, session,
       "peril_flood" = input$chkinputprflood,
       "peril_surge" = input$chkinputprstsurge,
       "leakage_factor" = input$sliderleakagefac,
-      "event_occurrence_file_id" =  as.integer(input$sinputeventocc),
+      "event_occurrence_id" =  as.integer(input$sinputeventocc),
       #outoutSettingsMappings
       "gul_output" = input$chkinputGUL,
       "il_output" = input$chkinputIL,


### PR DESCRIPTION
closes #55 
 "event_occurrence_file_id" is  "event_occurrence_id" is replaced with  "event_occurrence_id"  to be in line with the model execution in the most recent version. (tagged 1.0.1), as coded into the oasislmf package under:
https://github.com/OasisLMF/OasisLMF/blob/develop/oasislmf/model_execution/bin.py#L200