### PR TITLE
Fix/106 row selected

### DIFF
--- a/BFE_RShiny/flamingo/R/anainputs_module.R
+++ b/BFE_RShiny/flamingo/R/anainputs_module.R
@@ -126,7 +126,7 @@ anainputs <- function(input,
   # Reload input generated table -----------------------------------------------
   .reloadInputs <- function(){
     logMessage(".reloadInputs called")
-    if (!is.null(analysisID()) && analysisID() != "") {
+    if (!is.null(analysisID())) {
       dt_generated <- return_analyses_input_file_wicons_df(analysisID())
       if (!is.null(dt_generated)) {
         dt_generated <- .replace_uploaded_files(dt_generated, portfolioID())

--- a/BFE_RShiny/flamingo/R/analysis_details_module.R
+++ b/BFE_RShiny/flamingo/R/analysis_details_module.R
@@ -66,7 +66,7 @@ analysis_details <- function(input,
   }, {
     if (length(counter()) > 0 && counter() > 0) {
       if ((!is.null(portfolioID()) && !is.na(portfolioID()) && portfolioID() != "") &&
-          (!is.null(analysisID()) && !is.na(analysisID()))) {
+          (!is.null(analysisID()))) {
         extractFolder <- set_extractFolder(analysisID(), label = "_inputs/")
         if (!file.exists(extractFolder) && is.na(file.size(extractFolder))) {
           withModalSpinner(

--- a/BFE_RShiny/flamingo/R/analysis_details_module.R
+++ b/BFE_RShiny/flamingo/R/analysis_details_module.R
@@ -66,7 +66,7 @@ analysis_details <- function(input,
   }, {
     if (length(counter()) > 0 && counter() > 0) {
       if ((!is.null(portfolioID()) && !is.na(portfolioID()) && portfolioID() != "") &&
-          (!is.null(analysisID()) && !is.na(analysisID()) && analysisID() != "")) {
+          (!is.null(analysisID()) && !is.na(analysisID()))) {
         extractFolder <- set_extractFolder(analysisID(), label = "_inputs/")
         if (!file.exists(extractFolder) && is.na(file.size(extractFolder))) {
           withModalSpinner(

--- a/BFE_RShiny/flamingo/R/defineID.R
+++ b/BFE_RShiny/flamingo/R/defineID.R
@@ -73,8 +73,8 @@ defineIDUI <- function(id, w, batch = FALSE){
 #'
 #' @export
 defineID <- function(input, output, session,
-                     preselAnaId = reactive(-1),
-                     anaID = reactive(-1),
+                     preselAnaId = reactive(NULL),
+                     anaID = reactive(NULL),
                      batch = FALSE,
                      active = reactive(TRUE),
                      logMessage = message) {
@@ -84,7 +84,7 @@ defineID <- function(input, output, session,
   # Reactive Values and parameters ---------------------------------------------
   result <- reactiveValues(
     tbl_analysesData = NULL,
-    selectAnaID = "",
+    selectAnaID = NULL,
     selectAnaName = "",
     selectportfolioID = "",
     preselRow = NULL
@@ -224,7 +224,7 @@ defineID <- function(input, output, session,
   })
 
   output$selectAnaInfo2 <- renderText({
-    if (result$selectAnaID == "") {
+    if (is.null(result$selectAnaID)) {
       info <- '" - "'
     } else {
       info <- paste0(result$selectAnaID, ' "' ,result$selectAnaName, '"  ')

--- a/BFE_RShiny/flamingo/R/defineID.R
+++ b/BFE_RShiny/flamingo/R/defineID.R
@@ -101,14 +101,13 @@ defineID <- function(input, output, session,
 
   # Modal for AnaID selection --------------------------------------------------
 
+  tbl_analysesData <- return_tbl_analysesData()
+
   #Find row of anaid preselected in landing page
   observeEvent({
     preselAnaId()}, ignoreNULL = TRUE, {
-      tbl_analysesData <- return_tbl_analysesData()
-      if (!is.null(tbl_analysesData) && nrow(tbl_analysesData) > 0) {
-        result$tbl_analysesData <- tbl_analysesData  %>%
-          filter(!! sym(tbl_analysesDataNames$status) == Status$Completed)
-      }
+      result$tbl_analysesData <- tbl_analysesData  %>%
+        filter(!!sym(tbl_analysesDataNames$status) == Status$Completed)
       idx <- which(result$tbl_analysesData[,tbl_analysesDataNames$id] == preselAnaId())
       if (length(idx) > 0 && !isTRUE(all.equal(result$preselRow, idx))
           && !isTRUE(all.equal(sub_modules$flamingo_analyses$rows_selected(), idx))) {
@@ -119,15 +118,11 @@ defineID <- function(input, output, session,
   #Find row of anaid preselected in model analysis server step 3
   observeEvent({
     anaID()}, ignoreNULL = TRUE, {
-      tbl_analysesData <- return_tbl_analysesData()
-      if (!is.null(tbl_analysesData) && nrow(tbl_analysesData) > 0) {
-        result$tbl_analysesData <- tbl_analysesData  %>%
-          filter(!! sym(tbl_analysesDataNames$status) == Status$Completed)
-      }
+      result$tbl_analysesData <- tbl_analysesData  %>%
+        filter(!!sym(tbl_analysesDataNames$status) == Status$Completed)
       logMessage(paste0("Updating preselected row because anaID() changed to ", anaID()))
       idx <- which(result$tbl_analysesData[,tbl_analysesDataNames$id] == anaID())
-      if (length(idx) > 0 && !isTRUE(all.equal(sub_modules$flamingo_analyses$rows_selected(), idx))
-          && !is.null(anaID())) {
+      if (length(idx) > 0 && !isTRUE(all.equal(sub_modules$flamingo_analyses$rows_selected(), idx))) {
         result$preselRow <- idx
       }
     })
@@ -173,8 +168,7 @@ defineID <- function(input, output, session,
 
   # > open modal
   observeEvent(
-    input$chooseAnaID, {
-      tbl_analysesData <- return_tbl_analysesData()
+    input$chooseAnaID, ignoreNULL = TRUE, {
       if (!is.null(tbl_analysesData) && nrow(tbl_analysesData) > 0) {
         result$tbl_analysesData <- tbl_analysesData  %>%
           filter(!! sym(tbl_analysesDataNames$status) == Status$Completed)

--- a/BFE_RShiny/flamingo/R/defineID.R
+++ b/BFE_RShiny/flamingo/R/defineID.R
@@ -122,11 +122,14 @@ defineID <- function(input, output, session,
   )
 
   # > update list of analyses
-  observeEvent(input$chooseAnaID, ignoreNULL = TRUE, {
+  observeEvent({
+    input$chooseAnaID
+    preselAnaId()
+    anaID()}, ignoreInit = TRUE, {
       tbl_analysesData  <- return_tbl_analysesData()
       if (!is.null(tbl_analysesData) && nrow(tbl_analysesData) > 0) {
         result$tbl_analysesData <- tbl_analysesData  %>%
-          filter(!!sym(tbl_analysesDataNames$status) == Status$Completed)
+          filter(!! sym(tbl_analysesDataNames$status) == Status$Completed)
       }
       showModal(AnaList)
     })

--- a/BFE_RShiny/flamingo/R/defineID.R
+++ b/BFE_RShiny/flamingo/R/defineID.R
@@ -121,30 +121,21 @@ defineID <- function(input, output, session,
     )
   )
 
-  # > update lsit of analyses
-  observeEvent({
-    input$chooseAnaID
-    preselAnaId()
-    anaID()}, ignoreInit = TRUE, {
+  # > update list of analyses
+  observeEvent(input$chooseAnaID, ignoreNULL = TRUE, {
       tbl_analysesData  <- return_tbl_analysesData()
       if (!is.null(tbl_analysesData) && nrow(tbl_analysesData) > 0) {
         result$tbl_analysesData <- tbl_analysesData  %>%
-          filter(!! sym(tbl_analysesDataNames$status) == Status$Completed)
+          filter(!!sym(tbl_analysesDataNames$status) == Status$Completed)
       }
-    })
-
-  # > open modal
-  observeEvent(
-    input$chooseAnaID, {
       showModal(AnaList)
     })
-
 
   # > modal content
   sub_modules$flamingo_analyses <- callModule(
     flamingoTable,
     id = "flamingo_analyses",
-    data = reactive(result$tbl_analysesData),
+    data = reactive({result$tbl_analysesData}),
     selection = "single",
     escape = FALSE,
     filter = FALSE,
@@ -177,7 +168,7 @@ defineID <- function(input, output, session,
     anaID()},{
       logMessage(paste0("Updating preselected row because anaID() changed to ", anaID()))
       idx <- which(result$tbl_analysesData[,tbl_analysesDataNames$id] == anaID())
-      if (length(idx) > 0 && !isTRUE(all.equal(sub_modules$flamingo_analyses$rows_selected(), idx)) && anaID() != -1) {
+      if (length(idx) > 0 && !isTRUE(all.equal(sub_modules$flamingo_analyses$rows_selected(), idx))) {
         result$preselRow <- idx
       }
     })
@@ -187,9 +178,9 @@ defineID <- function(input, output, session,
   observeEvent(result$preselRow, {
     if (!is.null( result$preselRow)) {
       withModalSpinner(
-      .downloadOutput(idx = result$preselRow),
-      "Loading...",
-      size = "s"
+        .downloadOutput(idx = result$preselRow),
+        "Loading...",
+        size = "s"
       )
     }
   })
@@ -227,14 +218,14 @@ defineID <- function(input, output, session,
     if (is.null(result$selectAnaID)) {
       info <- '" - "'
     } else {
-      info <- paste0(result$selectAnaID, ' "' ,result$selectAnaName, '"  ')
+      info <- paste0(result$selectAnaID, ' "' , result$selectAnaName, '"  ')
     }
     info
   })
 
   # Help functions -------------------------------------------------------------
   .downloadOutput <- function(idx) {
-    currid <- ""
+    currid <- NULL
     currName <- ""
     currpfId <- ""
     if (!is.null(idx)) {

--- a/BFE_RShiny/flamingo/R/defineID.R
+++ b/BFE_RShiny/flamingo/R/defineID.R
@@ -242,7 +242,7 @@ defineID <- function(input, output, session,
       currName <- result$tbl_analysesData[idx, tbl_analysesDataNames$name]
       currpfId <- result$tbl_analysesData[idx, tbl_analysesDataNames$portfolio]
     }
-    result$selectAnaID <- ifelse(is.null(currid) | is.na(currid), "", currid)
+    result$selectAnaID <- ifelse(is.null(currid) | is.na(currid), NULL, currid)
     result$selectAnaName <-  ifelse(is.null(currName) | is.na(currName), "", currName)
     result$selectportfolioID <- ifelse(is.null(currpfId) | is.na(currpfId), "", currpfId)
     logMessage("Extract output files")

--- a/BFE_RShiny/flamingo/R/defineID.R
+++ b/BFE_RShiny/flamingo/R/defineID.R
@@ -131,7 +131,6 @@ defineID <- function(input, output, session,
         result$tbl_analysesData <- tbl_analysesData  %>%
           filter(!! sym(tbl_analysesDataNames$status) == Status$Completed)
       }
-      showModal(AnaList)
     })
 
   # > open modal

--- a/BFE_RShiny/flamingo/R/defineID.R
+++ b/BFE_RShiny/flamingo/R/defineID.R
@@ -221,9 +221,9 @@ defineID <- function(input, output, session,
       currName <- result$tbl_analysesData[idx, tbl_analysesDataNames$name]
       currpfId <- result$tbl_analysesData[idx, tbl_analysesDataNames$portfolio]
     }
-    result$selectAnaID <- ifelse(is.null(currid) | is.na(currid), NULL, currid)
-    result$selectAnaName <-  ifelse(is.null(currName) | is.na(currName), "", currName)
-    result$selectportfolioID <- ifelse(is.null(currpfId) | is.na(currpfId), "", currpfId)
+    result$selectAnaID <- ifelse(is.null(currid), NULL, currid)
+    result$selectAnaName <-  ifelse(is.null(currName) || is.na(currName), "", currName)
+    result$selectportfolioID <- ifelse(is.null(currpfId) || is.na(currpfId), "", currpfId)
     logMessage("Extract output files")
     api_get_analyses_output_file(result$selectAnaID)
   }

--- a/BFE_RShiny/flamingo/R/defineID.R
+++ b/BFE_RShiny/flamingo/R/defineID.R
@@ -131,6 +131,12 @@ defineID <- function(input, output, session,
       showModal(AnaList)
     })
 
+  # > open modal
+  observeEvent(
+    input$chooseAnaID, {
+      showModal(AnaList)
+    })
+
   # > modal content
   sub_modules$flamingo_analyses <- callModule(
     flamingoTable,
@@ -168,7 +174,8 @@ defineID <- function(input, output, session,
     anaID()},{
       logMessage(paste0("Updating preselected row because anaID() changed to ", anaID()))
       idx <- which(result$tbl_analysesData[,tbl_analysesDataNames$id] == anaID())
-      if (length(idx) > 0 && !isTRUE(all.equal(sub_modules$flamingo_analyses$rows_selected(), idx))) {
+      if (length(idx) > 0 && !isTRUE(all.equal(sub_modules$flamingo_analyses$rows_selected(), idx))
+          && !is.null(anaID())) {
         result$preselRow <- idx
       }
     })

--- a/BFE_RShiny/flamingo/R/exposurevalidation_map_module.R
+++ b/BFE_RShiny/flamingo/R/exposurevalidation_map_module.R
@@ -60,7 +60,7 @@ exposurevalidationmapUI <- function(id) {
 exposurevalidationmap <- function(input,
                                   output,
                                   session,
-                                  analysisID = NULL,
+                                  analysisID = reactive(NULL),
                                   portfolioID = "",
                                   counter = reactive(NULL),
                                   active = reactive(TRUE)) {

--- a/BFE_RShiny/flamingo/R/exposurevalidation_map_module.R
+++ b/BFE_RShiny/flamingo/R/exposurevalidation_map_module.R
@@ -60,7 +60,7 @@ exposurevalidationmapUI <- function(id) {
 exposurevalidationmap <- function(input,
                                   output,
                                   session,
-                                  analysisID = "",
+                                  analysisID = NULL,
                                   portfolioID = "",
                                   counter = reactive(NULL),
                                   active = reactive(TRUE)) {

--- a/BFE_RShiny/flamingo/R/exposurevalidation_summary_module.R
+++ b/BFE_RShiny/flamingo/R/exposurevalidation_summary_module.R
@@ -71,7 +71,7 @@ exposurevalidationsummaryUI <- function(id) {
 exposurevalidationsummary <- function(input,
                                       output,
                                       session,
-                                      analysisID = "",
+                                      analysisID = NULL,
                                       portfolioID = "",
                                       counter = reactive(NULL),
                                       active = reactive(TRUE)) {

--- a/BFE_RShiny/flamingo/R/exposurevalidation_summary_module.R
+++ b/BFE_RShiny/flamingo/R/exposurevalidation_summary_module.R
@@ -71,7 +71,7 @@ exposurevalidationsummaryUI <- function(id) {
 exposurevalidationsummary <- function(input,
                                       output,
                                       session,
-                                      analysisID = NULL,
+                                      analysisID = reactive(NULL),
                                       portfolioID = "",
                                       counter = reactive(NULL),
                                       active = reactive(TRUE)) {

--- a/BFE_RShiny/flamingo/R/landingpage_module.R
+++ b/BFE_RShiny/flamingo/R/landingpage_module.R
@@ -66,7 +66,7 @@ landingPage <- function(input, output, session, logMessage = message, active = r
 
   result <- reactiveValues(
     tbl_anaInbox = NULL,
-    anaID = -1
+    anaID = NULL
   )
 
   # navigation -----------------------------------------------------------------
@@ -87,7 +87,7 @@ landingPage <- function(input, output, session, logMessage = message, active = r
 
   observe(if (active()) {
     # Reset Param
-    result$anaID <- -1
+    result$anaID <- NULL
 
     # invalidate if the refresh button updates
     force(input$abuttonrefreshanaInbox)

--- a/BFE_RShiny/flamingo/R/outputfiles_module.R
+++ b/BFE_RShiny/flamingo/R/outputfiles_module.R
@@ -47,7 +47,7 @@ outputfilesUI <- function(id) {
 #' @export
 outputfiles <- function(input, output, session,
                         tbl_filesListDataana = reactive(NULL),
-                        anaId = reactive(""),
+                        anaId = reactive(NULL),
                         portfolioId = reactive(""),
                         active = reactive(TRUE)) {
 

--- a/BFE_RShiny/flamingo/R/singleAna_server.R
+++ b/BFE_RShiny/flamingo/R/singleAna_server.R
@@ -22,7 +22,7 @@
 #' @export
 singleAna <- function(input, output, session,
                      active = reactive(TRUE), logMessage = message,
-                     selectAnaID = reactive(""),
+                     selectAnaID = reactive(NULL),
                      selectPortfolioID = reactive(""),
                      preselPanel = reactive(1)) {
 
@@ -38,9 +38,9 @@ singleAna <- function(input, output, session,
   # > Reactive Values ----------------------------------------------------------
   result <- reactiveValues(
     # Id of the analysis to use in dashboard
-    dashboardanaID = -1,
+    dashboardanaID = NULL,
     # Id of analysis
-    anaID = "",
+    anaID = NULL,
     # Id of the portfolio
     portfolioID = "",
     # Portfolio table
@@ -64,7 +64,7 @@ singleAna <- function(input, output, session,
   # and to panel 3 if coming from Browse
   observe(if (active()) {
     workflowSteps$update(analysisWorkflowSteps[[preselPanel()]])
-    result$dashboardanaID <- -1
+    result$dashboardanaID <- NULL
   })
 
   observeEvent(workflowSteps$step(), ignoreInit = TRUE, {
@@ -148,7 +148,7 @@ singleAna <- function(input, output, session,
   observeEvent(submodulesList$step2_chooseAnalysis$analysisID(), ignoreInit = TRUE, {
     anaID <- submodulesList$step2_chooseAnalysis$analysisID()
     #Avoid updating input if not necessary
-    if (!is.null(anaID) && !is.na(anaID) && anaID != "" && anaID != result$anaID) {
+    if (!is.null(anaID) && !is.na(anaID) && anaID != "") {
       logMessage(paste0("updating result$anaID because submodulesList$step2_chooseAnalysis$analysisID() changed to: ", anaID ))
       result$anaID <- anaID
     }

--- a/BFE_RShiny/flamingo/R/singleAna_server.R
+++ b/BFE_RShiny/flamingo/R/singleAna_server.R
@@ -136,33 +136,22 @@ singleAna <- function(input, output, session,
   })
 
   # > AnaId --------------------------------------------------------------------
-  observeEvent({submodulesList$step3_configureOutput$dashboardAnaID()
-    result$anaID}, ignoreInit = TRUE, ignoreNULL = TRUE, {
-      anaID <- submodulesList$step3_configureOutput$dashboardAnaID()
-      #Avoid updating input if not necessary
-      if (result$anaID != anaID) {
-        logMessage(paste0("updating result$anaID because submodulesList$step3_configureOutput$dashboardAnaID() changed to: ", anaID ))
-        result$dashboardanaID <- anaID
-      }
-    })
+  observeEvent(submodulesList$step3_configureOutput$dashboardAnaID(), ignoreNULL = TRUE, {
+    anaID <- submodulesList$step3_configureOutput$dashboardAnaID()
+    logMessage(paste0("updating result$anaID because submodulesList$step3_configureOutput$dashboardAnaID() changed to: ", anaID ))
+    result$dashboardanaID <- anaID
+  })
 
-  observeEvent({submodulesList$step2_chooseAnalysis$analysisID()
-    result$anaID}, ignoreInit = TRUE, ignoreNULL = TRUE, {
-      anaID <- submodulesList$step2_chooseAnalysis$analysisID()
-      #Avoid updating input if not necessary
-      if (result$anaID != anaID) {
-        logMessage(paste0("updating result$anaID because submodulesList$step2_chooseAnalysis$analysisID() changed to: ", anaID ))
-        result$anaID <- anaID
-      }
-    })
+  observeEvent(submodulesList$step2_chooseAnalysis$analysisID(), ignoreNULL = TRUE, {
+    anaID <- submodulesList$step2_chooseAnalysis$analysisID()
+    logMessage(paste0("updating result$anaID because submodulesList$step2_chooseAnalysis$analysisID() changed to: ", anaID ))
+    result$anaID <- anaID
+  })
 
-  observeEvent(selectAnaID(), ignoreInit = TRUE, ignoreNULL = TRUE, {
+  observeEvent(selectAnaID(), ignoreNULL = TRUE, {
     anaID <- selectAnaID()
-    #Avoid updating input if not necessary
-    if (result$anaID != anaID) {
-      logMessage(paste0("updating result$anaID because selectAnaID() changed to: ", anaID ))
-      result$anaID <- anaID
-    }
+    logMessage(paste0("updating result$anaID because selectAnaID() changed to: ", anaID))
+    result$anaID <- anaID
   })
 
   # > portfolioID --------------------------------------------------------------

--- a/BFE_RShiny/flamingo/R/singleAna_server.R
+++ b/BFE_RShiny/flamingo/R/singleAna_server.R
@@ -21,10 +21,10 @@
 #'
 #' @export
 singleAna <- function(input, output, session,
-                     active = reactive(TRUE), logMessage = message,
-                     selectAnaID = reactive(NULL),
-                     selectPortfolioID = reactive(""),
-                     preselPanel = reactive(1)) {
+                      active = reactive(TRUE), logMessage = message,
+                      selectAnaID = reactive(NULL),
+                      selectPortfolioID = reactive(""),
+                      preselPanel = reactive(1)) {
 
   ns <- session$ns
 
@@ -136,28 +136,30 @@ singleAna <- function(input, output, session,
   })
 
   # > AnaId --------------------------------------------------------------------
-  observeEvent(submodulesList$step3_configureOutput$dashboardAnaID(), ignoreInit = TRUE, {
-    anaID <- submodulesList$step3_configureOutput$dashboardAnaID()
-    #Avoid updating input if not necessary
-    if (!is.null(anaID) && !is.na(anaID) && anaID != -1) {
-      logMessage(paste0("updating result$anaID because submodulesList$step3_configureOutput$dashboardAnaID() changed to: ", anaID ))
-      result$dashboardanaID <- anaID
-    }
-  })
+  observeEvent({submodulesList$step3_configureOutput$dashboardAnaID()
+    result$anaID}, ignoreInit = TRUE, {
+      anaID <- submodulesList$step3_configureOutput$dashboardAnaID()
+      #Avoid updating input if not necessary
+      if (!is.null(anaID) && !is.na(anaID) && result$anaID != anaID) {
+        logMessage(paste0("updating result$anaID because submodulesList$step3_configureOutput$dashboardAnaID() changed to: ", anaID ))
+        result$dashboardanaID <- anaID
+      }
+    })
 
-  observeEvent(submodulesList$step2_chooseAnalysis$analysisID(), ignoreInit = TRUE, {
-    anaID <- submodulesList$step2_chooseAnalysis$analysisID()
-    #Avoid updating input if not necessary
-    if (!is.null(anaID) && !is.na(anaID)) {
-      logMessage(paste0("updating result$anaID because submodulesList$step2_chooseAnalysis$analysisID() changed to: ", anaID ))
-      result$anaID <- anaID
-    }
-  })
+  observeEvent({submodulesList$step2_chooseAnalysis$analysisID()
+    result$anaID}, ignoreInit = TRUE, {
+      anaID <- submodulesList$step2_chooseAnalysis$analysisID()
+      #Avoid updating input if not necessary
+      if (!is.null(anaID) && !is.na(anaID)  && result$anaID != anaID) {
+        logMessage(paste0("updating result$anaID because submodulesList$step2_chooseAnalysis$analysisID() changed to: ", anaID ))
+        result$anaID <- anaID
+      }
+    })
 
   observeEvent(selectAnaID(), ignoreInit = TRUE, {
     anaID <- selectAnaID()
     #Avoid updating input if not necessary
-    if (!is.null(anaID) && !is.na(anaID) && anaID != result$anaID) {
+    if (!is.null(anaID) && !is.na(anaID) && result$anaID != anaID) {
       logMessage(paste0("updating result$anaID because selectAnaID() changed to: ", anaID ))
       result$anaID <- anaID
     }

--- a/BFE_RShiny/flamingo/R/singleAna_server.R
+++ b/BFE_RShiny/flamingo/R/singleAna_server.R
@@ -139,7 +139,7 @@ singleAna <- function(input, output, session,
   observeEvent(submodulesList$step3_configureOutput$dashboardAnaID(), ignoreInit = TRUE, {
     anaID <- submodulesList$step3_configureOutput$dashboardAnaID()
     #Avoid updating input if not necessary
-    if (!is.null(anaID) && !is.na(anaID) && anaID != "" && anaID != -1) {
+    if (!is.null(anaID) && !is.na(anaID) && anaID != -1) {
       logMessage(paste0("updating result$anaID because submodulesList$step3_configureOutput$dashboardAnaID() changed to: ", anaID ))
       result$dashboardanaID <- anaID
     }
@@ -148,7 +148,7 @@ singleAna <- function(input, output, session,
   observeEvent(submodulesList$step2_chooseAnalysis$analysisID(), ignoreInit = TRUE, {
     anaID <- submodulesList$step2_chooseAnalysis$analysisID()
     #Avoid updating input if not necessary
-    if (!is.null(anaID) && !is.na(anaID) && anaID != "") {
+    if (!is.null(anaID) && !is.na(anaID)) {
       logMessage(paste0("updating result$anaID because submodulesList$step2_chooseAnalysis$analysisID() changed to: ", anaID ))
       result$anaID <- anaID
     }
@@ -157,7 +157,7 @@ singleAna <- function(input, output, session,
   observeEvent(selectAnaID(), ignoreInit = TRUE, {
     anaID <- selectAnaID()
     #Avoid updating input if not necessary
-    if (!is.null(anaID) && !is.na(anaID) && anaID != "" && anaID != result$anaID) {
+    if (!is.null(anaID) && !is.na(anaID) && anaID != result$anaID) {
       logMessage(paste0("updating result$anaID because selectAnaID() changed to: ", anaID ))
       result$anaID <- anaID
     }

--- a/BFE_RShiny/flamingo/R/singleAna_server.R
+++ b/BFE_RShiny/flamingo/R/singleAna_server.R
@@ -133,21 +133,18 @@ singleAna <- function(input, output, session,
 
   # > AnaId --------------------------------------------------------------------
   observeEvent(submodulesList$step3_configureOutput$dashboardAnaID(), {
-    anaID <- submodulesList$step3_configureOutput$dashboardAnaID()
-    logMessage(paste0("updating result$anaID because submodulesList$step3_configureOutput$dashboardAnaID() changed to: ", anaID ))
-    result$dashboardanaID <- anaID
+    result$dashboardanaID <- submodulesList$step3_configureOutput$dashboardAnaID()
+    logMessage(paste0("updating result$anaID because submodulesList$step3_configureOutput$dashboardAnaID() changed to: ", result$dashboardanaID))
   })
 
   observeEvent(submodulesList$step2_chooseAnalysis$analysisID(), {
-    anaID <- submodulesList$step2_chooseAnalysis$analysisID()
-    logMessage(paste0("updating result$anaID because submodulesList$step2_chooseAnalysis$analysisID() changed to: ", anaID ))
-    result$anaID <- anaID
+    result$anaID <- submodulesList$step2_chooseAnalysis$analysisID()
+    logMessage(paste0("updating result$anaID because submodulesList$step2_chooseAnalysis$analysisID() changed to: ", result$anaID))
   })
 
   observeEvent(selectAnaID(), {
-    anaID <- selectAnaID()
-    logMessage(paste0("updating result$anaID because selectAnaID() changed to: ", anaID))
-    result$anaID <- anaID
+    result$anaID <- selectAnaID()
+    logMessage(paste0("updating result$anaID because selectAnaID() changed to: ", result$anaID))
   })
 
   # > portfolioID --------------------------------------------------------------

--- a/BFE_RShiny/flamingo/R/singleAna_server.R
+++ b/BFE_RShiny/flamingo/R/singleAna_server.R
@@ -137,29 +137,29 @@ singleAna <- function(input, output, session,
 
   # > AnaId --------------------------------------------------------------------
   observeEvent({submodulesList$step3_configureOutput$dashboardAnaID()
-    result$anaID}, ignoreInit = TRUE, {
+    result$anaID}, ignoreInit = TRUE, ignoreNULL = TRUE, {
       anaID <- submodulesList$step3_configureOutput$dashboardAnaID()
       #Avoid updating input if not necessary
-      if (!is.null(anaID) && !is.na(anaID) && result$anaID != anaID) {
+      if (result$anaID != anaID) {
         logMessage(paste0("updating result$anaID because submodulesList$step3_configureOutput$dashboardAnaID() changed to: ", anaID ))
         result$dashboardanaID <- anaID
       }
     })
 
   observeEvent({submodulesList$step2_chooseAnalysis$analysisID()
-    result$anaID}, ignoreInit = TRUE, {
+    result$anaID}, ignoreInit = TRUE, ignoreNULL = TRUE, {
       anaID <- submodulesList$step2_chooseAnalysis$analysisID()
       #Avoid updating input if not necessary
-      if (!is.null(anaID) && !is.na(anaID)  && result$anaID != anaID) {
+      if (result$anaID != anaID) {
         logMessage(paste0("updating result$anaID because submodulesList$step2_chooseAnalysis$analysisID() changed to: ", anaID ))
         result$anaID <- anaID
       }
     })
 
-  observeEvent(selectAnaID(), ignoreInit = TRUE, {
+  observeEvent(selectAnaID(), ignoreInit = TRUE, ignoreNULL = TRUE, {
     anaID <- selectAnaID()
     #Avoid updating input if not necessary
-    if (!is.null(anaID) && !is.na(anaID) && result$anaID != anaID) {
+    if (result$anaID != anaID) {
       logMessage(paste0("updating result$anaID because selectAnaID() changed to: ", anaID ))
       result$anaID <- anaID
     }

--- a/BFE_RShiny/flamingo/R/step2_chooseAnalysis_module.R
+++ b/BFE_RShiny/flamingo/R/step2_chooseAnalysis_module.R
@@ -494,7 +494,7 @@ step2_chooseAnalysis <- function(input, output, session,
 
   #  panelAnalysisLog Table title
   output$paneltitle_panelAnalysisLog <- renderUI({
-    if (is.null(result$analysisID)) {
+    if (!is.null(result$analysisID)) {
       anaName <- result$tbl_analysesData[input$dt_analyses_rows_selected, tbl_analysesDataNames$name]
       paste0('Input generation Logs of analysis id ', toString(result$analysisID), ' ', anaName)
     } else {
@@ -504,7 +504,7 @@ step2_chooseAnalysis <- function(input, output, session,
 
   #  analysis_details Table title
   output$paneltitle_analysis_details <- renderUI({
-    if (is.null(result$analysisID)) {
+    if (!is.null(result$analysisID)) {
       anaName <- result$tbl_analysesData[input$dt_analyses_rows_selected, tbl_analysesDataNames$name]
       analysisID <- result$tbl_analysesData[input$dt_analyses_rows_selected, tbl_analysesDataNames$id]
       paste0('Details of analysis id ', toString(analysisID), ' ', anaName)

--- a/BFE_RShiny/flamingo/R/step2_chooseAnalysis_module.R
+++ b/BFE_RShiny/flamingo/R/step2_chooseAnalysis_module.R
@@ -234,7 +234,7 @@ step2_chooseAnalysis <- function(input, output, session,
     #analysis log
     tbl_analysislog = NULL,
     #analysis ID
-    analysisID = ""
+    analysisID = NULL
   )
 
   #Set Params
@@ -251,6 +251,7 @@ step2_chooseAnalysis <- function(input, output, session,
   observeEvent({
     currstep()
     portfolioID()}, {
+      .hideDivs()
       .hideDivs()
       if (currstep() == 2 ) {
         .defaultAssociateModel()

--- a/BFE_RShiny/flamingo/R/step2_chooseAnalysis_module.R
+++ b/BFE_RShiny/flamingo/R/step2_chooseAnalysis_module.R
@@ -252,8 +252,7 @@ step2_chooseAnalysis <- function(input, output, session,
     currstep()
     portfolioID()}, {
       .hideDivs()
-      .hideDivs()
-      if (currstep() == 2 ) {
+      if (currstep() == 2) {
         .defaultAssociateModel()
         .reloadAnaData()
         .reloadtbl_modelsData()

--- a/BFE_RShiny/flamingo/R/step2_chooseAnalysis_module.R
+++ b/BFE_RShiny/flamingo/R/step2_chooseAnalysis_module.R
@@ -310,7 +310,7 @@ step2_chooseAnalysis <- function(input, output, session,
       if (!is.null(input$dt_analyses_rows_selected)) {
         result$analysisID <- result$tbl_analysesData[input$dt_analyses_rows_selected, tbl_analysesDataNames$id]
       } else {
-        result$analysisID <- ""
+        result$analysisID <- NULL
       }
     })
 
@@ -494,7 +494,7 @@ step2_chooseAnalysis <- function(input, output, session,
 
   #  panelAnalysisLog Table title
   output$paneltitle_panelAnalysisLog <- renderUI({
-    if (result$analysisID != "") {
+    if (is.null(result$analysisID)) {
       anaName <- result$tbl_analysesData[input$dt_analyses_rows_selected, tbl_analysesDataNames$name]
       paste0('Input generation Logs of analysis id ', toString(result$analysisID), ' ', anaName)
     } else {
@@ -504,7 +504,7 @@ step2_chooseAnalysis <- function(input, output, session,
 
   #  analysis_details Table title
   output$paneltitle_analysis_details <- renderUI({
-    if (result$analysisID != "") {
+    if (is.null(result$analysisID)) {
       anaName <- result$tbl_analysesData[input$dt_analyses_rows_selected, tbl_analysesDataNames$name]
       analysisID <- result$tbl_analysesData[input$dt_analyses_rows_selected, tbl_analysesDataNames$id]
       paste0('Details of analysis id ', toString(analysisID), ' ', anaName)
@@ -719,7 +719,7 @@ step2_chooseAnalysis <- function(input, output, session,
   # Reload Analysis Log table
   .reloadAnaLog <- function() {
     logMessage(".reloadAnaLog called")
-    if (!is.null(result$analysisID) && result$analysisID != "") {
+    if (!is.null(result$analysisID)) {
       result$tbl_analysislog <- return_file_df(api_get_analyses_input_generation_traceback_file, result$analysisID)
     } else {
       result$tbl_analysislog <-  NULL

--- a/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
+++ b/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
@@ -431,7 +431,7 @@ step3_configureOutput <- function(input, output, session,
                                   currstep = reactive(-1),
                                   portfolioID = reactive(""),
                                   pfName = reactive(""),
-                                  analysisID = reactive("")
+                                  analysisID = reactive(NULL)
 ) {
 
   ns <- session$ns
@@ -459,7 +459,7 @@ step3_configureOutput <- function(input, output, session,
     # flag to know if the user is creating a new output configuration or rerunning an analysis
     ana_flag = "C",
     # Id of the Analysis
-    anaID = -1,
+    anaID = NULL,
     # anaId for Dashboard
     dashboardAnaID = -1,
     # analysis_ setting
@@ -556,7 +556,7 @@ step3_configureOutput <- function(input, output, session,
 
   output$dt_analyses <- renderDT(
     if (!is.null(result$tbl_analysesData) && nrow(result$tbl_analysesData) > 0) {
-      index <- which(result$tbl_analysesData[,tbl_analysesDataNames$id] == result$anaID )
+      index <- which(result$tbl_analysesData[ ,tbl_analysesDataNames$id] == result$anaID)
       if (length(index) == 0) {
         index <- 1
       }
@@ -920,8 +920,6 @@ step3_configureOutput <- function(input, output, session,
           show("panelAnalysisLogs")
           logMessage("showing analysis run log table")
         }
-      } else {
-        result$anaID <- -1
       }
     }
   })
@@ -972,7 +970,7 @@ step3_configureOutput <- function(input, output, session,
   # Reload Analysis Run Log table
   .reloadAnaRunLog <- function() {
     logMessage(".reloadAnaRunLog called")
-    if (!is.null(result$anaID) && result$anaID != "") {
+    if (!is.null(result$anaID)) {
       result$tbl_analysisrunlog <- return_file_df(api_get_analyses_run_traceback_file, result$anaID)
     } else {
       result$tbl_analysisrunlog <-  NULL

--- a/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
+++ b/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
@@ -160,7 +160,7 @@ panelDefineOutputsDetails <- function(id) {
           hidden(selectInput(ns("sinputeventocc"), label = "Event Occurrence Set:", choices = "")),
           h5("Available Perils"),
           uiOutput(ns("chkinputsperils"))
-          ),
+      ),
       hidden(div(id = ns("configureAnaParamsAdvanced"), align = "left",
                  textInput(ns("tinputnoofsample"), label = "Number of Samples:", value = "10"),
                  textInput(ns("tinputthreshold"), label = "Loss Threshold:", value = "0"),
@@ -448,8 +448,6 @@ step3_configureOutput <- function(input, output, session,
 
   # > Reactive Values ----------------------------------------------------------
   result <- reactiveValues(
-    # reactive for portfolioID
-    portfolioID = "",
     # reactve value for navigation
     navigationstate = NULL,
     # reactive value for Analysis table
@@ -470,9 +468,6 @@ step3_configureOutput <- function(input, output, session,
   observe(if (active()) {
     result$navigationstate <- NULL
     result$dashboardAnaID <- NULL
-    if (!is.null(analysisID())) {
-      result$anaID <- analysisID()
-    }
   })
 
 
@@ -556,8 +551,8 @@ step3_configureOutput <- function(input, output, session,
 
   output$dt_analyses <- renderDT(
     if (!is.null(result$tbl_analysesData) && nrow(result$tbl_analysesData) > 0) {
-      index <- which(result$tbl_analysesData[ ,tbl_analysesDataNames$id] == result$anaID)
-      if (length(index) == 0 && is.null(result$anaID)) {
+      index <- which(result$tbl_analysesData[ ,tbl_analysesDataNames$id] == analysisID())
+      if (length(index) == 0 && is.null(analysisID())) {
         index <- 1
       }
       logMessage("re-rendering analysis table")
@@ -854,7 +849,7 @@ step3_configureOutput <- function(input, output, session,
              row.names = FALSE,
              col.names = FALSE,
              quote = FALSE)
-      }
+    }
   )
 
   observeEvent(result$tbl_analysisrunlog, {
@@ -907,13 +902,13 @@ step3_configureOutput <- function(input, output, session,
   # Allow display output option only if run successful. Otherwise default view is logs
   observeEvent({
     input$dt_analyses_rows_selected
-    portfolioID()
+    result$tbl_analysesData
   }, ignoreNULL = FALSE, ignoreInit = TRUE, {
-    if (length(input$dt_analyses_rows_selected) > 0) {
+    if (active()) {
       logMessage(paste("input$dt_analyses_rows_selected is changed to:", input$dt_analyses_rows_selected))
       hide("panelDefineOutputs")
       hide("panelAnalysisLogs")
-      if (max(input$dt_analyses_rows_selected) <= nrow(result$tbl_analysesData)) {
+      if (length(input$dt_analyses_rows_selected) > 0 && !is.null(result$tbl_analysesData) && nrow(result$tbl_analysesData) > 0 && max(input$dt_analyses_rows_selected) <= nrow(result$tbl_analysesData)) {
         result$anaID <- result$tbl_analysesData[input$dt_analyses_rows_selected, tbl_analysesDataNames$id]
         logMessage(paste0("analysisId changed to ", result$anaID))
         if (result$tbl_analysesData[input$dt_analyses_rows_selected, tbl_analysesDataNames$status] == Status$Failed) {

--- a/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
+++ b/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
@@ -470,7 +470,7 @@ step3_configureOutput <- function(input, output, session,
   observe(if (active()) {
     result$navigationstate <- NULL
     result$dashboardAnaID <- NULL
-    if (!is.null(analysisID()) && analysisID() != "") {
+    if (!is.null(analysisID())) {
       result$anaID <- analysisID()
     }
   })
@@ -479,7 +479,7 @@ step3_configureOutput <- function(input, output, session,
   # Panels Visualization -------------------------------------------------------
   observeEvent(currstep(), {
     .hideDivs()
-    if (currstep() == 3 ) {
+    if (currstep() == 3) {
       .defaultstep3()
       .reloadAnaData()
     }
@@ -557,7 +557,7 @@ step3_configureOutput <- function(input, output, session,
   output$dt_analyses <- renderDT(
     if (!is.null(result$tbl_analysesData) && nrow(result$tbl_analysesData) > 0) {
       index <- which(result$tbl_analysesData[ ,tbl_analysesDataNames$id] == result$anaID)
-      if (length(index) == 0) {
+      if (length(index) == 0 && is.null(result$anaID)) {
         index <- 1
       }
       logMessage("re-rendering analysis table")
@@ -909,17 +909,19 @@ step3_configureOutput <- function(input, output, session,
     input$dt_analyses_rows_selected
     portfolioID()
   }, ignoreNULL = FALSE, ignoreInit = TRUE, {
-    if (active()) {
+    if (length(input$dt_analyses_rows_selected) > 0) {
       logMessage(paste("input$dt_analyses_rows_selected is changed to:", input$dt_analyses_rows_selected))
       hide("panelDefineOutputs")
       hide("panelAnalysisLogs")
-      if (length(input$dt_analyses_rows_selected) > 0 && !is.null(result$tbl_analysesData) && nrow(result$tbl_analysesData) > 0 && max(input$dt_analyses_rows_selected) <= nrow(result$tbl_analysesData)) {
+      if (max(input$dt_analyses_rows_selected) <= nrow(result$tbl_analysesData)) {
         result$anaID <- result$tbl_analysesData[input$dt_analyses_rows_selected, tbl_analysesDataNames$id]
         logMessage(paste0("analysisId changed to ", result$anaID))
         if (result$tbl_analysesData[input$dt_analyses_rows_selected, tbl_analysesDataNames$status] == Status$Failed) {
           show("panelAnalysisLogs")
           logMessage("showing analysis run log table")
         }
+      } else {
+        result$anaID <- NULL
       }
     }
   })

--- a/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
+++ b/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
@@ -468,6 +468,9 @@ step3_configureOutput <- function(input, output, session,
   observe(if (active()) {
     result$navigationstate <- NULL
     result$dashboardAnaID <- NULL
+    if (!is.null(analysisID())) {
+      result$anaID <- analysisID()
+    }
   })
 
 

--- a/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
+++ b/BFE_RShiny/flamingo/R/step3_configureOutput_module.R
@@ -461,7 +461,7 @@ step3_configureOutput <- function(input, output, session,
     # Id of the Analysis
     anaID = NULL,
     # anaId for Dashboard
-    dashboardAnaID = -1,
+    dashboardAnaID = NULL,
     # analysis_ setting
     analysis_settings = NULL
   )
@@ -469,7 +469,7 @@ step3_configureOutput <- function(input, output, session,
   # Reset Param
   observe(if (active()) {
     result$navigationstate <- NULL
-    result$dashboardAnaID <- -1
+    result$dashboardAnaID <- NULL
     if (!is.null(analysisID()) && analysisID() != "") {
       result$anaID <- analysisID()
     }

--- a/BFE_RShiny/flamingo/R/summary_module.R
+++ b/BFE_RShiny/flamingo/R/summary_module.R
@@ -83,8 +83,8 @@ summarytabUI <- function(id) {
 #'
 #' @export
 summarytab <- function(input, output, session,
-                       selectAnaID1 = reactive(""),
-                       selectAnaID2 = reactive(""),
+                       selectAnaID1 = reactive(NULL),
+                       selectAnaID2 = reactive(NULL),
                        portfolioID1 = reactive(""),
                        portfolioID2 = reactive(""),
                        tbl_filesListDataana1 = reactive(NULL),

--- a/BFE_RShiny/flamingo/R/summary_module.R
+++ b/BFE_RShiny/flamingo/R/summary_module.R
@@ -114,10 +114,10 @@ summarytab <- function(input, output, session,
       SummaryData2 <- NULL
       SummaryData <- NULL
 
-      if (selectAnaID1() != "" && portfolioID1() != "" && !is.null(tbl_filesListDataana1())) {
+      if (!is.null(selectAnaID1()) && portfolioID1() != "" && !is.null(tbl_filesListDataana1())) {
         SummaryData1 <- .getSummary(selectAnaID1(), portfolioID1())
       }
-      if (selectAnaID2() != "" && portfolioID2() != "" && !is.null(tbl_filesListDataana1())) {
+      if (!is.null(selectAnaID2()) && portfolioID2() != "" && !is.null(tbl_filesListDataana1())) {
         SummaryData2 <- .getSummary(selectAnaID2(), portfolioID2())
       }
 

--- a/BFE_RShiny/flamingo/R/visualizationBBR_server.R
+++ b/BFE_RShiny/flamingo/R/visualizationBBR_server.R
@@ -81,7 +81,7 @@ visualizationBBR <- function(input, output, session,
 
   # Extract Output files for given anaID----------------------------------------
   observeEvent(sub_modules$defineID$selectAnaID(), {
-    if (!is.na(sub_modules$defineID$selectAnaID()) && sub_modules$defineID$selectAnaID() != "") {
+    if (!is.null(sub_modules$defineID$selectAnaID())) {
       tbl_filesListDataana <- return_analyses_output_file_df(sub_modules$defineID$selectAnaID())
       analysis_settings <- return_analyses_settings_file_list(sub_modules$defineID$selectAnaID())
       result$tbl_filesListDataana <- cbind(tbl_filesListDataana,

--- a/BFE_RShiny/flamingo/R/visualizationBBR_server.R
+++ b/BFE_RShiny/flamingo/R/visualizationBBR_server.R
@@ -22,8 +22,8 @@
 #'
 #' @export
 visualizationBBR <- function(input, output, session,
-                             preselAnaId = reactive(-1),
-                             anaID  = reactive(-1),
+                             preselAnaId = reactive(NULL),
+                             anaID  = reactive(NULL),
                              active = reactive(TRUE), logMessage = message) {
 
   ns <- session$ns
@@ -39,7 +39,7 @@ visualizationBBR <- function(input, output, session,
     #Panel to select
     preselPanel = 1,
     #id of selected analysis
-    selectAnaID = "",
+    selectAnaID = NULL,
     #portfolio id of selected analysis
     selectPortfolioID = "",
     # df analysis output files
@@ -55,7 +55,7 @@ visualizationBBR <- function(input, output, session,
   observeEvent(active(), {
     if (active()) {
       result$preselPanel <- 1
-      result$selectAnaID <- ""
+      result$selectAnaID <- NULL
       result$selectPortfolioID = ""
     }
   })

--- a/BFE_RShiny/flamingo/R/visualizationCBR_server.R
+++ b/BFE_RShiny/flamingo/R/visualizationCBR_server.R
@@ -21,8 +21,8 @@
 #' @export
 visualizationCBR <- function(input, output, session,
                              active = reactive(TRUE),
-                             preselAnaId = reactive(-1),
-                             anaID  = reactive(-1),
+                             preselAnaId = reactive(NULL),
+                             anaID = reactive(NULL),
                              logMessage = message) {
 
   ns <- session$ns
@@ -38,7 +38,7 @@ visualizationCBR <- function(input, output, session,
     #Panel to select
     preselPanel = 1,
     #id of selected analysis
-    selectAnaID = "",
+    selectAnaID = NULL,
     #portfolio id of selected analysis
     selectPortfolioID = "",
     # df analysis output files
@@ -54,7 +54,7 @@ visualizationCBR <- function(input, output, session,
   observeEvent(active(), {
     if (active()) {
       result$preselPanel <- 1
-      result$selectAnaID <- ""
+      result$selectAnaID <- NULL
       result$selectPortfolioID = ""
     }
   })

--- a/BFE_RShiny/flamingo/R/visualizationCBR_server.R
+++ b/BFE_RShiny/flamingo/R/visualizationCBR_server.R
@@ -103,8 +103,7 @@ visualizationCBR <- function(input, output, session,
   observeEvent( {
     sub_modules$defineID1$selectAnaID()
     sub_modules$defineID2$selectAnaID()}, {
-      if (!is.na(sub_modules$defineID1$selectAnaID()) && sub_modules$defineID1$selectAnaID() != "" &&
-          !is.na(sub_modules$defineID2$selectAnaID()) && sub_modules$defineID2$selectAnaID() != "") {
+      if (!is.null(sub_modules$defineID1$selectAnaID()) && !is.null(sub_modules$defineID2$selectAnaID())) {
         tbl_filesListDataana1 <- return_analyses_output_file_df(sub_modules$defineID1$selectAnaID())
         analysis_settings1 <- return_analyses_settings_file_list(sub_modules$defineID1$selectAnaID())
         result$tbl_filesListDataana <- cbind(tbl_filesListDataana1,

--- a/BFE_RShiny/flamingo/R/visualizationSBR_server.R
+++ b/BFE_RShiny/flamingo/R/visualizationSBR_server.R
@@ -78,7 +78,7 @@ visualizationSBR <- function(input, output, session,
 
   # Extract Output files for given anaID----------------------------------------
   observeEvent(sub_modules$defineID$selectAnaID(), {
-    if (!is.na(sub_modules$defineID$selectAnaID()) && sub_modules$defineID$selectAnaID() != "") {
+    if (!is.null(sub_modules$defineID$selectAnaID())) {
       tbl_filesListDataana <- return_analyses_output_file_df(sub_modules$defineID$selectAnaID())
       analysis_settings <- return_analyses_settings_file_list(sub_modules$defineID$selectAnaID())
       result$tbl_filesListDataana <- cbind(tbl_filesListDataana,
@@ -106,7 +106,7 @@ visualizationSBR <- function(input, output, session,
     outputfiles,
     id = "outputfiles",
     tbl_filesListDataana =  reactive(result$tbl_filesListDataana),
-    anaId = sub_modules$defineID$selectAnaID,
+    anaId = reactive(sub_modules$defineID$selectAnaID()),
     portfolioId = sub_modules$defineID$selectPortfolioID,
     active = reactive({active() && input$tabsSBR == ns("taboutputfiles")}))
 

--- a/BFE_RShiny/flamingo/R/visualizationSBR_server.R
+++ b/BFE_RShiny/flamingo/R/visualizationSBR_server.R
@@ -22,8 +22,8 @@
 #'
 #' @export
 visualizationSBR <- function(input, output, session,
-                             preselAnaId = reactive(-1),
-                             anaID  = reactive(-1),
+                             preselAnaId = reactive(NULL),
+                             anaID  = reactive(NULL),
                              active = reactive(TRUE), logMessage = message) {
 
   ns <- session$ns
@@ -37,7 +37,7 @@ visualizationSBR <- function(input, output, session,
     #Panel to select
     preselPanel = 1,
     #id of selected analysis
-    selectAnaID = "",
+    selectAnaID = NULL,
     #portfolio id of selected analysis
     selectPortfolioID = "",
     # df analysis output files
@@ -53,7 +53,7 @@ visualizationSBR <- function(input, output, session,
   observeEvent(active(), {
     if (active()) {
       result$preselPanel <- 1
-      result$selectAnaID <- ""
+      result$selectAnaID <- NULL
       result$selectPortfolioID = ""
     }
   })

--- a/BFE_RShiny/flamingo/inst/app/server.R
+++ b/BFE_RShiny/flamingo/inst/app/server.R
@@ -97,7 +97,7 @@ server <- function(input, output, session) {
   auth_modules$visualizationSBR <- callModule(
     visualizationSBR,
     id = "visualizationSBR",
-    preselAnaId =  auth_modules$landingPage$anaID,
+    preselAnaId = auth_modules$landingPage$anaID,
     anaID = auth_modules$singleAna$anaID,
     logMessage = logMessage,
     active = reactive(authenticated() && main_visible() == "SBR")

--- a/BFE_RShiny/flamingo/inst/app/server.R
+++ b/BFE_RShiny/flamingo/inst/app/server.R
@@ -106,8 +106,8 @@ server <- function(input, output, session) {
   auth_modules$visualizationBBR <- callModule(
     visualizationBBR,
     id = "visualizationBBR",
-    preselAnaId = reactive(-1),
-    anaID = reactive(-1),
+    preselAnaId = reactive(NULL),
+    anaID = reactive(NULL),
     logMessage = logMessage,
     active = reactive(authenticated() && main_visible() == "BBR")
   )
@@ -115,8 +115,8 @@ server <- function(input, output, session) {
   auth_modules$visualizationCBR <- callModule(
     visualizationCBR,
     id = "visualizationCBR",
-    preselAnaId = reactive(-1),
-    anaID =  reactive(-1),
+    preselAnaId = reactive(NULL),
+    anaID =  reactive(NULL),
     logMessage = logMessage,
     active = reactive(authenticated() && main_visible() == "CBR")
   )

--- a/BFE_RShiny/flamingo/man/defineID.Rd
+++ b/BFE_RShiny/flamingo/man/defineID.Rd
@@ -7,8 +7,8 @@
 \usage{
 defineIDUI(id, w, batch = FALSE)
 
-defineID(input, output, session, preselAnaId = reactive(-1),
-  anaID = reactive(-1), batch = FALSE, active = reactive(TRUE),
+defineID(input, output, session, preselAnaId = reactive(NULL),
+  anaID = reactive(NULL), batch = FALSE, active = reactive(TRUE),
   logMessage = message)
 }
 \arguments{

--- a/BFE_RShiny/flamingo/man/exposurevalidationmap.Rd
+++ b/BFE_RShiny/flamingo/man/exposurevalidationmap.Rd
@@ -7,7 +7,7 @@
 \usage{
 exposurevalidationmapUI(id)
 
-exposurevalidationmap(input, output, session, analysisID = "",
+exposurevalidationmap(input, output, session, analysisID = NULL,
   portfolioID = "", counter = reactive(NULL),
   active = reactive(TRUE))
 }

--- a/BFE_RShiny/flamingo/man/exposurevalidationsummary.Rd
+++ b/BFE_RShiny/flamingo/man/exposurevalidationsummary.Rd
@@ -7,7 +7,7 @@
 \usage{
 exposurevalidationsummaryUI(id)
 
-exposurevalidationsummary(input, output, session, analysisID = "",
+exposurevalidationsummary(input, output, session, analysisID = NULL,
   portfolioID = "", counter = reactive(NULL),
   active = reactive(TRUE))
 }

--- a/BFE_RShiny/flamingo/man/outputfiles.Rd
+++ b/BFE_RShiny/flamingo/man/outputfiles.Rd
@@ -8,7 +8,7 @@
 outputfilesUI(id)
 
 outputfiles(input, output, session,
-  tbl_filesListDataana = reactive(NULL), anaId = reactive(""),
+  tbl_filesListDataana = reactive(NULL), anaId = reactive(NULL),
   portfolioId = reactive(""), active = reactive(TRUE))
 }
 \arguments{

--- a/BFE_RShiny/flamingo/man/singleAna.Rd
+++ b/BFE_RShiny/flamingo/man/singleAna.Rd
@@ -6,7 +6,7 @@
 \title{singleAna}
 \usage{
 singleAna(input, output, session, active = reactive(TRUE),
-  logMessage = message, selectAnaID = reactive(""),
+  logMessage = message, selectAnaID = reactive(NULL),
   selectPortfolioID = reactive(""), preselPanel = reactive(1))
 
 singleAnaUI(id)

--- a/BFE_RShiny/flamingo/man/step3_configureOutput.Rd
+++ b/BFE_RShiny/flamingo/man/step3_configureOutput.Rd
@@ -10,7 +10,7 @@ step3_configureOutputUI(id)
 step3_configureOutput(input, output, session, active = reactive(TRUE),
   logMessage = message, currstep = reactive(-1),
   portfolioID = reactive(""), pfName = reactive(""),
-  analysisID = reactive(""))
+  analysisID = reactive(NULL))
 }
 \arguments{
 \item{id}{module id}

--- a/BFE_RShiny/flamingo/man/summarytab.Rd
+++ b/BFE_RShiny/flamingo/man/summarytab.Rd
@@ -7,8 +7,8 @@
 \usage{
 summarytabUI(id)
 
-summarytab(input, output, session, selectAnaID1 = reactive(""),
-  selectAnaID2 = reactive(""), portfolioID1 = reactive(""),
+summarytab(input, output, session, selectAnaID1 = reactive(NULL),
+  selectAnaID2 = reactive(NULL), portfolioID1 = reactive(""),
   portfolioID2 = reactive(""), tbl_filesListDataana1 = reactive(NULL),
   compare = FALSE, active, logMessage = message)
 }

--- a/BFE_RShiny/flamingo/man/visualizationBBR.Rd
+++ b/BFE_RShiny/flamingo/man/visualizationBBR.Rd
@@ -6,8 +6,8 @@
 \alias{visualizationBBRUI}
 \title{visualizationBBR}
 \usage{
-visualizationBBR(input, output, session, preselAnaId = reactive(-1),
-  anaID = reactive(-1), active = reactive(TRUE),
+visualizationBBR(input, output, session, preselAnaId = reactive(NULL),
+  anaID = reactive(NULL), active = reactive(TRUE),
   logMessage = message)
 
 visualizationBBRUI(id)

--- a/BFE_RShiny/flamingo/man/visualizationCBR.Rd
+++ b/BFE_RShiny/flamingo/man/visualizationCBR.Rd
@@ -8,7 +8,7 @@
 visualizationCBR}
 \usage{
 visualizationCBR(input, output, session, active = reactive(TRUE),
-  preselAnaId = reactive(-1), anaID = reactive(-1),
+  preselAnaId = reactive(NULL), anaID = reactive(NULL),
   logMessage = message)
 
 visualizationCBRUI(id)

--- a/BFE_RShiny/flamingo/man/visualizationSBR.Rd
+++ b/BFE_RShiny/flamingo/man/visualizationSBR.Rd
@@ -6,8 +6,8 @@
 \alias{visualizationSBRUI}
 \title{visualizationSBR}
 \usage{
-visualizationSBR(input, output, session, preselAnaId = reactive(-1),
-  anaID = reactive(-1), active = reactive(TRUE),
+visualizationSBR(input, output, session, preselAnaId = reactive(NULL),
+  anaID = reactive(NULL), active = reactive(TRUE),
   logMessage = message)
 
 visualizationSBRUI(id)


### PR DESCRIPTION
#closes 106
- row in analysis table can now be un-selected in step 3 
- no double re-load of table
- analysis ID (and related forms) are all now set to NULL, instead of " " or NA