### PR TITLE
Hotfix/analysis settings bug

### DIFF
--- a/BFE_RShiny/oasisui/R/buildCustom_module.R
+++ b/BFE_RShiny/oasisui/R/buildCustom_module.R
@@ -53,7 +53,7 @@ buildCustomUI <- function(id) {
 #' @param portfolioID Selected portfolio ID.
 #' @param modelID Selected model ID.
 #' @param supplierID Selected supplier model ID.
-#' @param versionID Selected model ID version.
+#' @param nameID Selected model ID version.
 #' @param analysisID Selected analysis ID.
 #'
 #' @describeIn buildCustom Allows user to build their own mode on the fly.
@@ -71,7 +71,7 @@ buildCustom <- function(input,
                         portfolioID,
                         modelID,
                         supplierID,
-                        versionID,
+                        nameID,
                         analysisID,
                         counter,
                         active = reactive(TRUE)) {
@@ -395,7 +395,7 @@ buildCustom <- function(input,
     result$filtered_analysis_settings <- list(analysis_settings = c(
       list(
         model_supplier_id = supplierID(),
-        model_name_id = versionID(),
+        model_name_id = nameID(),
         number_of_samples = input$inputnumsamples,
         model_settings = c(filtered_settings, result$list_files),
         gul_output = FALSE,

--- a/BFE_RShiny/oasisui/R/buildCustom_module.R
+++ b/BFE_RShiny/oasisui/R/buildCustom_module.R
@@ -395,7 +395,7 @@ buildCustom <- function(input,
     result$filtered_analysis_settings <- list(analysis_settings = c(
       list(
         model_supplier_id = supplierID(),
-        model_name_id = modelID(),
+        model_name_id = versionID(),
         number_of_samples = input$inputnumsamples,
         model_settings = c(filtered_settings, result$list_files),
         gul_output = FALSE,

--- a/BFE_RShiny/oasisui/R/step2_chooseAnalysis_module.R
+++ b/BFE_RShiny/oasisui/R/step2_chooseAnalysis_module.R
@@ -224,7 +224,7 @@ step2_chooseAnalysis <- function(input, output, session,
   result <- reactiveValues(
     # reactive for modelID
     modelID = "",
-    versionID = "",
+    nameID = "",
     supplierID = "",
     # reactive value for model table
     tbl_modelsData = NULL,
@@ -319,7 +319,7 @@ step2_chooseAnalysis <- function(input, output, session,
     portfolioID()}, ignoreNULL = FALSE, {
       if (!is.null(input$dt_models_rows_selected)) {
         result$modelID <- result$tbl_modelsData[input$dt_models_rows_selected, tbl_modelsDataNames$id]
-        result$versionID <- result$tbl_modelsData[input$dt_models_rows_selected, tbl_modelsDataNames$version_id]
+        result$nameID <- result$tbl_modelsData[input$dt_models_rows_selected, tbl_modelsDataNames$model_id]
         result$supplierID <- result$tbl_modelsData[input$dt_models_rows_selected, tbl_modelsDataNames$supplier_id]
       } else {
         result$modelID <- ""
@@ -628,7 +628,7 @@ step2_chooseAnalysis <- function(input, output, session,
     portfolioID = reactive({portfolioID()}),
     modelID = reactive({result$modelID}),
     supplierID = reactive({result$supplierID}),
-    versionID = reactive({result$versionID}),
+    nameID = reactive({result$nameID}),
     analysisID = reactive({result$analysisID}),
     counter = reactive({input$abuttonbuildcustom}),
     active = reactive(TRUE)
@@ -687,7 +687,7 @@ step2_chooseAnalysis <- function(input, output, session,
         ana_settings_step_2 <- list(analysis_settings = c(
           list(
             model_supplier_id = result$supplierID,
-            model_name_id = result$versionID,
+            model_name_id = result$nameID,
             number_of_samples = 10,
             model_settings = NULL,
             gul_output = FALSE,

--- a/BFE_RShiny/oasisui/R/step2_chooseAnalysis_module.R
+++ b/BFE_RShiny/oasisui/R/step2_chooseAnalysis_module.R
@@ -687,7 +687,7 @@ step2_chooseAnalysis <- function(input, output, session,
         ana_settings_step_2 <- list(analysis_settings = c(
           list(
             model_supplier_id = result$supplierID,
-            model_name_id = result$modelID,
+            model_name_id = result$versionID,
             number_of_samples = 10,
             model_settings = NULL,
             gul_output = FALSE,

--- a/BFE_RShiny/oasisui/man/buildCustom.Rd
+++ b/BFE_RShiny/oasisui/man/buildCustom.Rd
@@ -11,7 +11,7 @@ buildCustom(
   portfolioID,
   modelID,
   supplierID,
-  versionID,
+  nameID,
   analysisID,
   counter,
   active = reactive(TRUE)
@@ -26,7 +26,7 @@ buildCustom(
 
 \item{supplierID}{Selected supplier model ID.}
 
-\item{versionID}{Selected model ID version.}
+\item{nameID}{Selected model name ID.}
 
 \item{analysisID}{Selected analysis ID.}
 


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed bug in the complex model workflow 
The analysis settings field was not set correcting in both versions `1.11.0` and `1.10.0`
* **Bug in 1.11.0** - the  `model_name_id`  was set as the API model reference ID and would cause the anaysis_settings post to fail with Bad Request 400
* **Bug in 1.10.0** - the `model_version_id` field was set with the wrong value, passing that to a complex model would cause the custom binary search to fail. 
<!--end_release_notes-->
