### PR TITLE
Fix/276 summary params

### DIFF
--- a/BFE_RShiny/oasisui/R/output_config_settings.R
+++ b/BFE_RShiny/oasisui/R/output_config_settings.R
@@ -8,14 +8,35 @@ output_options <- list(
   # granularities = c("LOB", "Location", "County","State", "Policy", "Portfolio"),
   losstypes = c("GUL", "IL", "RI"),
   # reports feasible in plot output:
-  variables = c("Full Sample", "ELT", "LEC Full Uncertainty AEP", "LEC Full Uncertainty OEP",
-                "LEC Wheatsheaf AEP", "LEC Wheatsheaf OEP", "LEC Mean Wheatsheaf AEP",
-                "LEC Mean Wheatsheaf OEP", "LEC Sample Mean AEP", "LEC Sample Mean OEP", "AAL","PLT", "ELT Sample",
-                "ELT Quantile", "ELT Moment", "PLT Sample", "PLT Quantile", "PLT Moment", "ALT Period",
-                "EPT Full Uncertainty AEP", "EPT Full Uncertainty OEP", "EPT Mean Sample AEP", "EPT Mean Sample OEP",
-                "EPT per Sample Mean AEP", "EPT per Sample Mean OEP", "Psept AEP", "Psept OEP"),
+  variables = c("Full Sample", "ELT",
+                "LEC Full Uncertainty AEP", "LEC Full Uncertainty OEP",
+                "LEC Wheatsheaf AEP", "LEC Wheatsheaf OEP",
+                "LEC Mean Wheatsheaf AEP", "LEC Mean Wheatsheaf OEP",
+                "LEC Sample Mean AEP", "LEC Sample Mean OEP",
+                "AAL", "PLT",
+                "ELT Sample", "ELT Quantile", "ELT Moment",
+                "PLT Sample", "PLT Quantile", "PLT Moment",
+                "ALT Period",
+                "EPT Full Uncertainty AEP", "EPT Full Uncertainty OEP",
+                "EPT Mean Sample AEP", "EPT Mean Sample OEP",
+                "EPT per Sample Mean AEP", "EPT per Sample Mean OEP",
+                "Psept AEP", "Psept OEP"),
+
   # order = c(6,2,3,4,1,5),
-  variables_default = c(FALSE, FALSE, TRUE, FALSE, FALSE, TRUE, TRUE, FALSE),
+  variables_default = c(FALSE, FALSE,
+                        TRUE, TRUE,
+                        FALSE, FALSE,
+                        FALSE, FALSE,
+                        FALSE, FALSE,
+                        TRUE, FALSE
+                        FALSE, FALSE, FALSE,
+                        FALSE, FALSE, FALSE,
+                        FALSE,
+                        FALSE, FALSE,
+                        FALSE, FALSE,
+                        FALSE, FALSE,
+                        FALSE, FALSE),
+
   # default empty string is interpreted as aggregation should happen across everything, i.e. without any specific summary level
   # REF: perhaps to be changed to "All Risks" and replace string with default_level elsewhere
   default_level = ""

--- a/BFE_RShiny/oasisui/R/output_config_settings.R
+++ b/BFE_RShiny/oasisui/R/output_config_settings.R
@@ -28,7 +28,7 @@ output_options <- list(
                         FALSE, FALSE,
                         FALSE, FALSE,
                         FALSE, FALSE,
-                        TRUE, FALSE
+                        TRUE, FALSE,
                         FALSE, FALSE, FALSE,
                         FALSE, FALSE, FALSE,
                         FALSE,


### PR DESCRIPTION
<!--start_release_notes-->
### Fix summary defaults 
Updated the default summary outputs to only include 
* full_uncertainty_aep
* full_uncertainty_oep
* aalcalc

**Example settings file:** 
```
{
  "analysis_tag": "1",
  "ui_config_tag": "Summary",
  "gul_threshold": 0,
  "model_name_id": "PiWind",
  "model_supplier_id": "OasisLMF",
  "number_of_samples": 10,
  "prog_id": 1,
  "source_tag": "dev",
  "gul_output": true,
  "gul_summaries": [
    {
      "aalcalc": true,
      "id": 1,
      "oed_fields": [],
      "lec_output": true,
      "leccalc": {
        "return_period_file": true,
        "full_uncertainty_aep": true,
        "full_uncertainty_oep": true
      },
      "ord_output": {}
    }
  ],
  "il_output": false,
  "ri_output": false,
  "model_settings": {
    "event_set": "p",
    "event_occurrence_id": "lt",
    "number_of_samples": 10
  }
}

```

<!--end_release_notes-->
