### PR TITLE
enable connecting to API behind https URL

### DIFF
--- a/BFE_RShiny/oasisui/R/oasisapi.R
+++ b/BFE_RShiny/oasisui/R/oasisapi.R
@@ -101,9 +101,9 @@ OasisAPI <- R6Class(
   # Public ----
   public = list(
     # > Initialize ----
-    initialize = function(httptype = "application/json", host, port, version, ...){
+    initialize = function(httptype = "application/json", host, port, version, scheme = c("http", "https"), ...) {
       private$httptype <- httptype
-      self$api_init(host, port)
+      self$api_init(host, port, scheme[1])
       private$version <- version
     },
     get_http_type = function(){

--- a/BFE_RShiny/oasisui/inst/app/global.R
+++ b/BFE_RShiny/oasisui/inst/app/global.R
@@ -16,11 +16,17 @@ loginfo("testing logger", logger = "oasisui.module")
 
 APISettings <- APIgetenv(server = "API_IP",
                          port = "API_PORT",
+                         scheme = "API_HTTPS",
                          version = "API_VERSION",
                          share_filepath = "API_SHARE_FILEPATH")
 
 options(oasisui.settings.api.server = APISettings$server)
 options(oasisui.settings.api.port = APISettings$port)
+if (isTRUE(as.logical(APISettings$scheme))) {
+  options(oasisui.settings.api.scheme = "https")
+} else {
+  options(oasisui.settings.api.scheme = "http")
+}
 options(oasisui.settings.api.httptype = "application/json")
 options(oasisui.settings.api.version = APISettings$version)
 options(oasisui.settings.api.share_filepath = APISettings$share_filepath)

--- a/BFE_RShiny/oasisui/inst/app/server.R
+++ b/BFE_RShiny/oasisui/inst/app/server.R
@@ -17,7 +17,12 @@ clean_downloadedData()
 server <- function(input, output, session) {
 
   #initialize oasisapi R6 classes for managing connection to API in OasisUI
-  session$userData$oasisapi <- OasisAPI$new(host = getOption("oasisui.settings.api.server"), port = getOption("oasisui.settings.api.port"), version = getOption("oasisui.settings.api.version"))
+  session$userData$oasisapi <- OasisAPI$new(
+    host = getOption("oasisui.settings.api.server"),
+    port = getOption("oasisui.settings.api.port"),
+    scheme = getOption("oasisui.settings.api.scheme"),
+    version = getOption("oasisui.settings.api.version")
+  )
 
   #per-session health check
   loginfo(paste("oasisui API server:", session$userData$oasisapi$get_url()), logger = "oasisui.module")


### PR DESCRIPTION
facilitate investigation of #283 

<!--start_release_notes-->
### Enable https scheme for API URL
So far the Oasis UI expected the API to run under a URL starting with HTTP, added an environment variable to switch to HTTPS.
To enable, set `API_HTTPS="True"` 

<!--end_release_notes-->
