### PR TITLE
Feature/239 output config options plus fixes

### DIFF
--- a/BFE_RShiny/oasisui/R/ViewFilesInTable_module.R
+++ b/BFE_RShiny/oasisui/R/ViewFilesInTable_module.R
@@ -109,27 +109,33 @@ ViewFilesInTable <- function(input, output, session,
     if (length(filesListData) > 0) {
       names(filesListData) <- tolower(names(filesListData))
       if (includechkbox) {
-        filesListData <- cbind(data.frame(selected = .shinyInput(oasisuiCheckboxButton,"srows_", nrow(filesListData), Label = NULL,
-                                                                 hidden = FALSE,
-                                                                 style = "background-color: white;
-                                                                          border-color: black;
-                                                                          color: white;
-                                                                          font-size: 10px;
-                                                                          text-shadow: none;
-                                                                          padding: 0px;
-                                                                          height: 16px;
-                                                                          width: 16px;",
-                                                                 icon = icon("check"),
-                                                                 onclick = paste0('Shiny.onInputChange(\"',ns("select_sbutton"),'\",  this.id)')
-        )),
-        filesListData)
+        filesListData <- cbind(
+          data.frame(selected = .shinyInput(oasisuiCheckboxButton,
+                                            "srows_",
+                                            nrow(filesListData),
+                                            Label = NULL,
+                                            hidden = FALSE,
+                                            style = "background-color: white;
+                                                    border-color: black;
+                                                    color: white;
+                                                    font-size: 10px;
+                                                    text-shadow: none;
+                                                    padding: 0px;
+                                                    height: 16px;
+                                                    width: 16px;",
+                                            icon = icon("check"),
+                                            onclick = paste0('Shiny.onInputChange(\"', ns("select_sbutton"), '\",  this.id)'))),
+          filesListData)
       }
-      filesListData <- cbind(filesListData,
-                             data.frame(view = .shinyInput(actionButton,
-                                                           "vrows_", nrow(filesListData),
-                                                           Label = "View", hidden = TRUE,
-                                                           onclick = paste0('Shiny.onInputChange(\"',ns("select_vbutton"),'\",  this.id)'),
-                                                           onmousedown = 'event.preventDefault(); event.stopPropagation(); return false;')))
+      filesListData <- cbind(
+        filesListData,
+        data.frame(view = .shinyInput(actionButton,
+                                      "vrows_",
+                                      nrow(filesListData),
+                                      Label = "View",
+                                      hidden = TRUE,
+                                      onclick = paste0('Shiny.onInputChange(\"', ns("select_vbutton"), '\",  this.id)'),
+                                      onmousedown = 'event.preventDefault(); event.stopPropagation(); return false;')))
       result$tbl_filesListData_wButtons <- filesListData
     } else {
       result$tbl_filesListData_wButtons <- NULL
@@ -196,6 +202,7 @@ ViewFilesInTable <- function(input, output, session,
   # Download file-- ------------------------------------------------------------
   # Export to .csv
   output$FLdownloadexcel <- downloadHandler(
+    # RSc: is this still working?
     filename = "file.csv",
     content = function(file) {
       session$userData$data_hub$write_csv_file(data = result$tbl_filesListData_wButton,
@@ -209,10 +216,12 @@ ViewFilesInTable <- function(input, output, session,
     if (length(input$dt_outputFL_rows_selected) > 0) {
       enable("FLdownloadzip")
       lapply(input$dt_outputFL_rows_selected, function(i) {
-        session$sendCustomMessage(type = 'resetcolorOasis', message =  session$ns( paste0("srows_", i)))
+        session$sendCustomMessage(type = 'resetcolorOasis', message =  session$ns(paste0("srows_", i)))
         show(paste0("vrows_", i))
         if (!is.null(result$tbl_filesListData_wButtons[i, "name"]) && result$tbl_filesListData_wButtons[i, "name"] == "Not Available") {
           disable(paste0("vrows_", i))
+          # 266: avoid download error for non-available files
+          disable("FLdownloadzip")
         }
       })
       lapply(setdiff(input$dt_outputFL_rows_current, input$dt_outputFL_rows_selected), function(i) {
@@ -244,7 +253,7 @@ ViewFilesInTable <- function(input, output, session,
     }
   })
 
-  #update checkboxes according to selectAll button
+  # update checkboxes according to selectAll button
   observeEvent(input$chkboxselectall, ignoreNULL = FALSE, ignoreInit = TRUE, {
     if (!is.null(result$tbl_filesListData_wButtons)) {
       if (!is.null(input$chkboxselectall) && input$chkboxselectall) {
@@ -460,7 +469,7 @@ ViewFilesInTable <- function(input, output, session,
 
   # Helper functions -----------------------------------------------------------
 
-  # utility function to add to buttons in table
+  # utility function to create a column with buttons that can be added to a table
   .shinyInput <- function(FUN, id, num, Label = NULL, hidden = FALSE,  ...) {
     inputs <- character(num)
     for (i in seq_len(num)) {

--- a/BFE_RShiny/oasisui/R/buildCustom_module.R
+++ b/BFE_RShiny/oasisui/R/buildCustom_module.R
@@ -347,9 +347,13 @@ buildCustom <- function(input,
                               float_input,
                               dropdown_input)
       # NULL or list() elements won't survive the c() above!
+
       # create list/vector of names for model settings
-      names_full_list <- c("event_set",
-                           "event_occurrence_id",
+      # 291 - allow event_set and event_occurrence_id to be missing for certain models, in which case we will simply have no basic params:
+      names_full_list <- c()
+      if (!is.null(input$event_set_g)) names_full_list <- c(names_full_list, "event_set")
+      if (!is.null(input$event_occurrence_g)) names_full_list <- c(names_full_list, "event_occurrence_id")
+      names_full_list <- c(names_full_list,
                            "number_of_samples",
                            boolean_name,
                            inputs_name)

--- a/BFE_RShiny/oasisui/R/check_loc.R
+++ b/BFE_RShiny/oasisui/R/check_loc.R
@@ -17,7 +17,6 @@
 #' @export
 check_loc <- function(analysisID, portfolioID, data_hub) {
   logMessage(".check_loc called")
-
   uploaded_locs <- data_hub$get_pf_location_content(id = portfolioID) %>%
     mutate(loc_idx = seq(nrow(.)) - 1)
   modelled_locs <- data_hub$get_ana_dataset_content(id = analysisID, dataset_identifier = "lookup_success_file")

--- a/BFE_RShiny/oasisui/R/helper_text.R
+++ b/BFE_RShiny/oasisui/R/helper_text.R
@@ -64,7 +64,9 @@ defineSingleAna_tooltips <- list(
   addBtn = "Add new summary levels and reports",
   removeBtn = "Remove summary levels and reports",
   abuttonsubmit = "Submit new analysis",
-  abuttonselsettings = "Apply model changes"
+  abuttonselsettings = "Apply model changes",
+  tinputreturnperiods = "Comma-separated numeric values",
+  tinputquantiles = "Comma-separated numeric values between 0 and 1"
 )
 
 ### Dashboard ------------------------------------------------------------------

--- a/BFE_RShiny/oasisui/R/login_server.R
+++ b/BFE_RShiny/oasisui/R/login_server.R
@@ -50,8 +50,8 @@ loginDialog <- function(input, output, session, logout) {
       session$userData$oasisapi$set_tokens(user, pwd)
       if (!is.null(session$userData$oasisapi$get_access_token())) {
         result$user <- user
-	#initialize data_hub R6 class to manage files and files lists in OasisUI
-        session$userData$data_hub <- DataHub$new(user =  session$userData$oasisapi$get_access_token(), destdir = getOption("oasisui.settings.api.share_filepath"), oasisapi = session$userData$oasisapi)
+        # initialize data_hub R6 class to manage files and files lists in OasisUI
+        session$userData$data_hub <- DataHub$new(user = session$userData$oasisapi$get_access_token(), destdir = getOption("oasisui.settings.api.share_filepath"), oasisapi = session$userData$oasisapi)
       } else {
         result$user = OASISUI_GUEST_ID
         oasisuiNotification("Login Failed, please check your credentials.", type = "error")

--- a/BFE_RShiny/oasisui/R/modelParams_funs.R
+++ b/BFE_RShiny/oasisui/R/modelParams_funs.R
@@ -12,7 +12,8 @@ basicConfig_funs <- function(session, model_settings) {
   ns <- session$ns
   # Event set
   .event_set_fun <- function(model_settings) {
-    if (is.null(model_settings$event_set.used_for) || model_settings$event_set.used_for == "losses") {
+    # 291 - allow event_set and event_occurrence_id to be missing for certain models, in which case we will simply have no basic params:
+    if (!is.null(model_settings$event_set.name) && is.null(model_settings$event_set.used_for) || model_settings$event_set.used_for == "losses") {
       selectChoices <- lapply(model_settings$event_set.options, function(x) {
         x$id
       })
@@ -33,7 +34,7 @@ basicConfig_funs <- function(session, model_settings) {
 
   # Event occurrence
   .event_occurrence_fun <- function(model_settings) {
-    if (is.null(model_settings$event_occurrence_id.used_for) || model_settings$event_occurrence_id.used_for == "losses") {
+    if (!is.null(model_settings$event_occurrence_id.name) && is.null(model_settings$event_occurrence_id.used_for) || model_settings$event_occurrence_id.used_for == "losses") {
       selectChoices <- lapply(model_settings$event_occurrence_id.options, function(x) {
         x$id
       })

--- a/BFE_RShiny/oasisui/R/oasisuiIncrementalPanel.R
+++ b/BFE_RShiny/oasisui/R/oasisuiIncrementalPanel.R
@@ -62,7 +62,7 @@ oasisuiIncrementalPanel <- function(input, output, session, panels_state,
   })
   observeEvent(input$del_ok, {
     removeModal()
-    cat("delete", id, "\n")
+    cat("oasisuiIncrementalPanel: delete", id, "\n")
     removeUI(sprintf("#%s", id), immediate = TRUE)
     panels_state[[id]] <- FALSE
   })
@@ -162,7 +162,7 @@ callIncrementalPanelModules <- function(IDs, ID_0,
     remove_all = function() {
       state_vec <- unlist(reactiveValuesToList(panels_state))
       IDs <- names(state_vec)[state_vec]
-      cat("delete", IDs, "\n")
+      cat("callIncrementalPanelModules: delete", IDs, "\n")
       lapply(IDs, function(id) {
         removeUI(sprintf("#%s", id), immediate = TRUE)
         panels_state[[id]] <- FALSE

--- a/BFE_RShiny/oasisui/R/output_config_module.R
+++ b/BFE_RShiny/oasisui/R/output_config_module.R
@@ -1154,8 +1154,11 @@ def_out_config <- function(input,
       # NULL or list() elements won't survive the c() above!
 
       # create list/vector of names for model settings
-      names_full_list <- c("event_set",
-                           "event_occurrence_id",
+      # 291 - allow event_set and event_occurrence_id to be missing for certain models, in which case we will simply have no basic params:
+      names_full_list <- c()
+      if (!is.null(input$event_set)) names_full_list <- c(names_full_list, "event_set")
+      if (!is.null(input$event_occurrence)) names_full_list <- c(names_full_list, "event_occurrence_id")
+      names_full_list <- c(names_full_list,
                            "number_of_samples",
                            boolean_name,
                            inputs_name)

--- a/BFE_RShiny/oasisui/R/output_config_module.R
+++ b/BFE_RShiny/oasisui/R/output_config_module.R
@@ -1190,10 +1190,12 @@ def_out_config <- function(input,
       "ui_config_tag" = input$sintag,
       # potential new tag analysis_id
       "gul_threshold" = as.integer(input$tinputthreshold),
-      # 239: insert additional output cfg options at the desired spot
-      "return_periods" = as.integer(strsplit(gsub(" ", "", input$tinputreturnperiods), ",")[[1]]),
-      "event_ids" = as.integer(strsplit(gsub(" ", "", input$tinputeventids), ",")[[1]]),
-      "quantiles" = as.numeric(strsplit(gsub(" ", "", input$tinputquantiles), ",")[[1]]),
+      # 239: insert additional output cfg options at the desired spot.
+      # these are explicitly lists because a single element would be converted
+      # differently to json otherwise
+      "return_periods" = as.list(as.integer(strsplit(gsub(" ", "", input$tinputreturnperiods), ",")[[1]])),
+      "event_ids" = as.list(as.integer(strsplit(gsub(" ", "", input$tinputeventids), ",")[[1]])),
+      "quantiles" = as.list(as.numeric(strsplit(gsub(" ", "", input$tinputquantiles), ",")[[1]])),
       "model_name_id" = modelData[[tbl_modelsDataNames$model_id]],
       "model_supplier_id" = modelData[[tbl_modelsDataNames$supplier_id]],
       "number_of_samples" = as.integer(input$tinputnoofsample),

--- a/BFE_RShiny/oasisui/R/output_config_module.R
+++ b/BFE_RShiny/oasisui/R/output_config_module.R
@@ -98,6 +98,7 @@ panelSettingsTemplates <- function(id) {
 #' @template params-module-ui
 #'
 #' @importFrom shinyjs hidden
+#' @importFrom bsplus bs_embed_tooltip
 #'
 #' @export
 panelModelParams <- function(id) {
@@ -119,6 +120,13 @@ panelModelParams <- function(id) {
           align = "left",
           numericInput(ns("tinputnoofsample"), label = "Number of Samples:", value = 9),
           numericInput(ns("tinputthreshold"), label = "Loss Threshold:", value = 0),
+          # 239: additional output cfg options (not part of modelsettings!)
+          textInput(ns("tinputreturnperiods"), label = "Return Periods:", value = "") %>%
+            bs_embed_tooltip(title = defineSingleAna_tooltips$tinputreturnperiods, placement = "right"),
+          textInput(ns("tinputeventids"), label = "Event IDs:", value = "") %>%
+            bs_embed_tooltip(title = defineSingleAna_tooltips$tinputreturnperiods, placement = "right"),
+          textInput(ns("tinputquantiles"), label = "Quantiles:", value = "") %>%
+            bs_embed_tooltip(title = defineSingleAna_tooltips$tinputquantiles, placement = "right"),
           uiOutput(ns("advanced_model_param")),
           oasisuiButton(inputId = ns("abuttonbasic"), label = "Basic")
         )
@@ -1179,6 +1187,10 @@ def_out_config <- function(input,
       "ui_config_tag" = input$sintag,
       # potential new tag analysis_id
       "gul_threshold" = as.integer(input$tinputthreshold),
+      # 239: insert additional output cfg options at the desired spot
+      "return_periods" = as.integer(strsplit(gsub(" ", "", input$tinputreturnperiods), ",")[[1]]),
+      "event_ids" = as.integer(strsplit(gsub(" ", "", input$tinputeventids), ",")[[1]]),
+      "quantiles" = as.numeric(strsplit(gsub(" ", "", input$tinputquantiles), ",")[[1]]),
       "model_name_id" = modelData[[tbl_modelsDataNames$model_id]],
       "model_supplier_id" = modelData[[tbl_modelsDataNames$supplier_id]],
       "number_of_samples" = as.integer(input$tinputnoofsample),
@@ -1188,6 +1200,14 @@ def_out_config <- function(input,
       # potential new tag environment_tag
       "source_tag" = getOption("oasisui.settings.oasis_environment")
     )
+    # 239: set to NULL if the lists are empty (i.e. exclude the fields from the analysis settings)
+    # this cannot be done directly above because elements that are assigned NULL during list creation will actually remain in the list with NULL values
+    if (length(inputsettings$return_periods) == 0)
+      inputsettings$return_periods <- NULL
+    if (length(inputsettings$event_ids) == 0)
+      inputsettings$event_ids <- NULL
+    if (length(inputsettings$quantiles) == 0)
+      inputsettings$quantiles <- NULL
 
     fetch_summary <- function(prsp, checked) {
       if (prsp %in% checked) {
@@ -1246,7 +1266,7 @@ def_out_config <- function(input,
           # update requested reports for summary level that is being iterated
           idx_item <- review_prsp$summary_level == fields_to_add[item]
           keep <- review_prsp[idx_item, "report"]
-          #TODO: check which ord reports are needed for plot and expand lec_list
+          # TODO: check which ord reports are needed for plot and expand lec_list
           lec_list <- c("LEC Full Uncertainty AEP", "LEC Full Uncertainty OEP",
                         "LEC Wheatsheaf AEP", "LEC Wheatsheaf OEP", "LEC Mean Wheatsheaf AEP",
                         "LEC Mean Wheatsheaf OEP", "LEC Sample Mean AEP", "LEC Sample Mean OEP")

--- a/BFE_RShiny/oasisui/R/step1_choosePortfolio_module.R
+++ b/BFE_RShiny/oasisui/R/step1_choosePortfolio_module.R
@@ -382,7 +382,7 @@ step1_choosePortfolio <- function(input, output, session,
     .defaultCreateProg()
     # TODO: review where/when/how this should be set
     result$portfolio_flag <- "A"
-    #clear fields
+    # clear fields
     .updatePortfolioName()
     show("panelDefinePortfolio")
     logMessage("showing panelDefinePortfolio")
@@ -647,12 +647,15 @@ step1_choosePortfolio <- function(input, output, session,
       if (length(input$dt_Portfolios_rows_selected) > 0) {
         # note that dt_Portfolios allows single row selection only
         pfID <- result$tbl_portfoliosData[input$dt_Portfolios_rows_selected, tbl_portfoliosDataNames$id]
-        # #If incomplete show panel to link files
-        currStatus <- result$tbl_portfoliosData[input$dt_Portfolios_rows_selected, tbl_portfoliosDataNames$status]
-        if (!is.na(currStatus) && currStatus == Status$Processing) {
+        # if incomplete show panel to link files
+        #currStatus <- result$tbl_portfoliosData[input$dt_Portfolios_rows_selected, tbl_portfoliosDataNames$status]
+        #if (!is.na(currStatus) && currStatus == Status$Processing) {
+        # 287: re-show the panel to upload source files in any case (to avoid
+        # having to re-open it when first uploading location file, which will lead
+        # to the analysis status being ready)
           .clearUploadFiles()
           show("panelLinkFiles")
-        }
+        #}
         if (pfID != result$portfolioID) {
           logMessage(paste("updating portfolioID because selection in portfolio table changed to", pfID))
           # re-selecting the same programme ID in the drop-down would not re-trigger
@@ -732,7 +735,11 @@ step1_choosePortfolio <- function(input, output, session,
         oasisuiNotification(type = "error",
                             paste("File link failed."))
       }
+      # we do this reload to get the portfoliosData table updated (i.e. the status of the portfolio may have changed to "ready")
       .reloadtbl_portfoliosData()
+      # panelLinkFiles gets hidden as part of the reload above but is shown again if the status of the portfolio is not "ready"
+      # (i.e. if there is no linked location file yet)
+      # we cannot change this by doing show("panelLinkFiles") here, it would happen before the reactive hiding above
     }
     invisible()
   }

--- a/BFE_RShiny/oasisui/R/summary_module.R
+++ b/BFE_RShiny/oasisui/R/summary_module.R
@@ -33,8 +33,11 @@ summarytabUI <- function(id) {
       ),
       column(6,
              plotlyOutput(ns("summaryGULOutputPlot")),
+             br(),
              plotlyOutput(ns("summaryAALOutputPlot")),
+             br(),
              plotlyOutput(ns("summaryILOutputPlot")),
+             br(),
              plotlyOutput(ns("summaryRIOutputPlot"))
       )
     )
@@ -558,8 +561,10 @@ basicplot <- function(xlabel, ylabel, titleToUse, data, group) {
 
 barPlot <- function(xlabel, ylabel, titleToUse, data, multipleplots){
   Perspective <- data$xaxis
-  Loss <- add_commas(data$value*1000000)
+  Loss <- add_commas(data$value * 1000000)
+
   p <- basicplot(xlabel, ylabel, titleToUse, data, group = Loss) +
+    # below throws warnings about unknown aesthetics, which are however used by plotly to prettify the mouse-over labels
     geom_bar(position = "dodge", stat = "identity", aes(fill = colour, prsp = Perspective, loss = Loss))
 
   if (multipleplots) {
@@ -567,7 +572,6 @@ barPlot <- function(xlabel, ylabel, titleToUse, data, multipleplots){
   }
   ggplotly(p, tooltip = c("colour", "prsp", "loss"))
 }
-
 
 #' linePlot structure
 #' @title linePlot
@@ -594,11 +598,12 @@ barPlot <- function(xlabel, ylabel, titleToUse, data, multipleplots){
 linePlot <- function(xlabel, ylabel, titleToUse, data) {
   RP <- add_commas(data$xaxis)
   #convert value back to the full length from Millions scale
-  Loss <- add_commas(data$value*1000000)
+  Loss <- add_commas(data$value * 1000000)
   Report <- data$colour
   data$xaxis <- as.factor(add_commas(data$xaxis))
 
   p <- basicplot(xlabel, ylabel, titleToUse, data, group = Report) +
+    # below throws warnings about unknown aesthetics, which are however used by plotly to prettify the mouse-over labels
     geom_point(size = 2, aes(color = Report, return = RP, loss = Loss), guides = FALSE) +
     geom_line(size = 1, aes(color = colour))
 


### PR DESCRIPTION
closes #239 
closes #286 
closes #287 
closes #291 

<!--start_release_notes-->
### New output configuration options
* Allows to set additional advanced params to select return periods, event IDs and/or quantiles in the output configuration step.

* Fixes a few other issues where the UI wasn't reflecting current new flexibility of the platform / API.
<!--end_release_notes-->
