### PR TITLE
Security patch for `1.11.1` -- needed for a production system

### DIFF
--- a/docker/Dockerfile.oasisui_app
+++ b/docker/Dockerfile.oasisui_app
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.0.5
+FROM rocker/r-ver:4.4.2
 # -> ubuntu 20.04
 # -> don't use latest R release, since that will keep getting linked with later build-dates and RStudio packagemanager
 # -> sets repository to RStudio packagemanager for specific build date of R version, being 2021-05-17 for R 4.0.5

--- a/docker/Dockerfile.oasisui_appli
+++ b/docker/Dockerfile.oasisui_appli
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.0.5
+FROM rocker/r-ver:4.4.2
 # -> ubuntu 20.04
 # -> don't use latest R release, since that will keep getting linked with later build-dates and RStudio packagemanager
 # -> sets repository to RStudio packagemanager for specific build date of R version, being 2021-05-17 for R 4.0.5


### PR DESCRIPTION
<!--start_release_notes-->
### Security patch for `1.11.1` -- needed for a production system
... Release notes description / summary 
... Any text between these two tags will be automatically pulled into the platform release notes 
<!--end_release_notes-->
