### PR TITLE
Upgrade ShinyProxy to 3.2.4 to fix CVE vulnerabilities

### DIFF
--- a/docker/Dockerfile.oasisui_proxy
+++ b/docker/Dockerfile.oasisui_proxy
@@ -1,10 +1,10 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y default-jre-headless iproute2
 
-ARG SHINY_VER='2.6.1'
+ARG SHINY_VER='3.2.4'
 ADD https://www.shinyproxy.io/downloads/shinyproxy-$SHINY_VER.jar ./shinyproxy.jar
 
 COPY ./shinyproxy/application.yml ./

--- a/shinyproxy/application.yml
+++ b/shinyproxy/application.yml
@@ -17,4 +17,4 @@ proxy:
 
 logging:
   file:
-    shinyproxy.log
+    name: shinyproxy.log

--- a/shinyproxy/application_fixedport.yml
+++ b/shinyproxy/application_fixedport.yml
@@ -23,4 +23,4 @@ shiny:
 
 logging:
   file:
-    shinyproxy.log
+    name: shinyproxy.log

--- a/shinyproxy/v1.1.0_application.yml
+++ b/shinyproxy/v1.1.0_application.yml
@@ -21,4 +21,4 @@ shiny:
 
 logging:
   file:
-    shinyproxy.log
+    name: shinyproxy.log


### PR DESCRIPTION
## Summary

- Upgrades ShinyProxy from 2.6.1 to 3.2.4, resolving 74 CVEs (13 critical, 61 high) listed in #337
- Updates base image from `ubuntu:20.04` to `ubuntu:24.04` to meet the JDK 17+ requirement of ShinyProxy 3.x
- Fixes `logging.file` → `logging.file.name` in all `application.yml` files for Spring Boot 3.x compatibility

## Test plan

- [ ] Build `Dockerfile.oasisui_proxy` and confirm image builds successfully
- [ ] Verify ShinyProxy starts and the Oasisui app launches correctly
- [ ] Confirm logging writes to `shinyproxy.log` as expected

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)